### PR TITLE
[wip] feat: deno?

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,0 +1,7 @@
+{
+   "imports": {
+      "./www/index": "./www/index.ts",
+      "wasm-game-of-life": "./pkg/wasm_game_of_life.js",
+      "wasm-game-of-life/wasm_game_of_life_bg": "./life.deno.ts"
+   }
+}

--- a/life.deno.ts
+++ b/life.deno.ts
@@ -1,0 +1,8 @@
+import init from "wasm-game-of-life";
+
+export let memory: WebAssembly.Memory;
+
+(async () =>
+  memory = <WebAssembly.Memory> (await init(
+    "http://localhost:8000/game.wasm",
+  )).memory)();

--- a/serve.ts
+++ b/serve.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env deno run --allow-net --allow-read --unstable --importmap import_map.json
+
+import * as Colors from "https://deno.land/std@v0.60.0/fmt/colors.ts";
+import { basename } from "https://deno.land/std@v0.60.0/path/mod.ts";
+
+// This is a bad idea: https://github.com/denoland/deno/issues/4549#issuecomment-610023095
+// > deno bundle will always be focused on creating workloads for Deno. The side-effect that
+// > some of those workloads can be run in a browser is "nice". Deno.bundle() is what is intended
+// > for building something for another runtime.
+// But since we're building a quick and dirty dev server anyway, this won't be the last bad idea in this file.
+const [diagnostics, emit] = await Deno.bundle("www/bootstrap.ts", undefined, {
+  lib: ["esnext", "es2017", "dom", "dom.iterable"],
+  target: "esnext",
+  module: "es2015",
+  experimentalDecorators: true,
+  sourceMap: true,
+});
+
+if (diagnostics != null) {
+  await diagnostics!
+    .map(
+      (d) =>
+        `
+${
+          Colors.yellow(
+            `${basename(d.scriptResourceName || "").trim()}:${
+              d.lineNumber ? d.lineNumber + 1 : NaN
+            }:${d.startColumn}-${d.endColumn}`,
+          )
+        } - ${Colors.red("error")} ${Colors.blue(`TS${d.code}`)}: ${d.message}
+${
+          Colors.bgWhite(
+            Colors.black(`${d.lineNumber ? d.lineNumber + 1 : NaN}`),
+          )
+        } ${d.sourceLine}
+`,
+    )
+    .forEach((m) => console.log(m));
+  Deno.exit(5);
+}
+// console.log(emit);
+
+import { serve } from "https://deno.land/std@v0.60.0/http/server.ts";
+const s = serve({ port: 8000 });
+console.log("http://localhost:8000/");
+for await (const req of s) {
+  if (req.url.match(/^\/$|^\/index.html$/)) {
+    const filename = "www/index.html";
+    const file = await Deno.open(filename);
+    const headers = new Headers();
+    // headers.set("Access-Control-Allow-Origin", "*");
+    await req.respond({ headers: headers, body: file });
+    file.close();
+  } else if (req.url.match(/^\/game.wasm$/)) {
+    const filename = "pkg/wasm_game_of_life_bg.wasm";
+    const file = await Deno.open(filename);
+    const headers = new Headers();
+    headers.set("content-type", "application/wasm");
+    await req.respond({ headers: headers, body: file });
+    file.close();
+  } else {
+    req.respond({ body: emit });
+  }
+}


### PR DESCRIPTION
Basically: can we rebuild the parts of webpack that we need with deno? So far, the answer is: yes, but we're not going to get much help doing it.

This code is building and serving a javascript bundle (from `wasm-pack build --target web`) alongside our index.html, but it's failing to load the `wasm` bits before trying to use them.